### PR TITLE
Allow for new admin email syntax

### DIFF
--- a/code/SparkPostAdmin.php
+++ b/code/SparkPostAdmin.php
@@ -866,6 +866,10 @@ class SparkPostAdmin extends LeftAndMain implements PermissionProvider
     {
         $email = SparkPostHelper::resolveDefaultFromEmail(null, false);
         if ($email) {
+            if (is_array($email)) {
+                $email = key($email);
+            }
+            
             $domain = substr(strrchr($email, "@"), 1);
             return $domain;
         }


### PR DESCRIPTION
When a display name is used, `admin_email` is an array where the key is the email and the value is the display name.

https://docs.silverstripe.org/en/4/developer_guides/email/#administrator-emails